### PR TITLE
Add more React-components

### DIFF
--- a/packages/ui/react-components/index.ts
+++ b/packages/ui/react-components/index.ts
@@ -1,5 +1,5 @@
 export { default as ContentWithTooltip } from './src/content-with-tooltip/ContentWithTooltip';
-export { default as DetailView } from './src/detail-view/DetailView';
+export { default as DetailView, DetailViewProps } from './src/detail-view/DetailView';
 export { default as IndicatorWithOverlay } from './src/indicator-with-overlay/IndicatorWithOverlay';
 export { default as InteractiveList } from './src/interactive-list/InteractiveList';
 export { default as NavigationWithDetailView } from './src/navigation-with-detail-view/NavigationWithDetailView';
@@ -8,3 +8,8 @@ export { default as Box, Margin } from './src/box/Box';
 export { default as Form } from './src/form/Form';
 export { default as PageContainer } from './src/page-container/PageContainer';
 export { default as PageError } from './src/page-error/PageError';
+export { default as BasicList } from './src/basic-list/BasicList';
+export { default as InfoPanel } from './src/info-panel/InfoPanel';
+export { default as LabelledContent } from './src/labelled-content/LabelledContent';
+export { default as LinkButton } from './src/link-button/LinkButton';
+export { default as TitleWithUnderline } from './src/title-with-underline/TitleWithUnderline';

--- a/packages/ui/react-components/package.json
+++ b/packages/ui/react-components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/k9-react-components",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "scripts": {
         "build": "rollup -c rollup.config.js",
         "clean": "rm -rf ./dist ./node_modules",
@@ -13,7 +13,6 @@
     "types": "./dist/index.d.ts",
     "files": [
         "dist",
-        "src",
         "index.ts",
         "package.json"
     ],
@@ -36,6 +35,7 @@
         "nav-frontend-js-utils": "^1.0.19",
         "nav-frontend-knapper": "^2.1.4",
         "nav-frontend-knapper-style": "^1.1.2",
+        "nav-frontend-paneler": "^3.0.1",
         "nav-frontend-paneler-style": "^2.0.1",
         "nav-frontend-spinner": "^3.0.1",
         "nav-frontend-spinner-style": "^1.0.2",
@@ -57,6 +57,7 @@
         "nav-frontend-js-utils": "^1.0.19",
         "nav-frontend-knapper": "^2.1.4",
         "nav-frontend-knapper-style": "^1.1.2",
+        "nav-frontend-paneler": "^3.0.1",
         "nav-frontend-paneler-style": "^2.0.1",
         "nav-frontend-spinner": "^3.0.1",
         "nav-frontend-spinner-style": "^1.0.2",

--- a/packages/ui/react-components/src/basic-list/BasicList.stories.tsx
+++ b/packages/ui/react-components/src/basic-list/BasicList.stories.tsx
@@ -1,0 +1,15 @@
+import React, { ComponentProps } from 'react';
+import { Story } from '@storybook/react';
+import BasicListComponent from './BasicList';
+
+export default {
+    title: 'React Components',
+    component: BasicListComponent,
+};
+
+const Template: Story<ComponentProps<typeof BasicListComponent>> = (args) => (
+    <BasicListComponent elements={[<p>Dette er et listeelement</p>, <p>Dette er et annet listeelmeent</p>]} />
+);
+
+export const BasicList = Template.bind({});
+BasicList.args = {};

--- a/packages/ui/react-components/src/basic-list/BasicList.tsx
+++ b/packages/ui/react-components/src/basic-list/BasicList.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import './basicList.less';
+
+export interface BasicListProps {
+    elements: React.ReactNode[];
+}
+
+const BasicList = ({ elements }: BasicListProps) => {
+    return (
+        <ul className="basicList">
+            {elements.map((element, index) => (
+                <li className="basicList__element" key={`element-${index}`}>
+                    {element}
+                </li>
+            ))}
+        </ul>
+    );
+};
+
+export default BasicList;

--- a/packages/ui/react-components/src/basic-list/basicList.less
+++ b/packages/ui/react-components/src/basic-list/basicList.less
@@ -1,0 +1,9 @@
+.basicList {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+
+  &__element {
+    margin-top: 0.5rem;
+  }
+}

--- a/packages/ui/react-components/src/detail-view/DetailView.stories.tsx
+++ b/packages/ui/react-components/src/detail-view/DetailView.stories.tsx
@@ -1,0 +1,17 @@
+import React, { ComponentProps } from 'react';
+import { Story } from '@storybook/react';
+import DetailViewComponent from './../detail-view/DetailView';
+
+export default {
+    title: 'React Components',
+    component: DetailViewComponent,
+};
+
+const Template: Story<ComponentProps<typeof DetailViewComponent>> = (args) => (
+    <DetailViewComponent title="Tittel">
+        <p>Detaljer</p>
+    </DetailViewComponent>
+);
+
+export const DetailView = Template.bind({});
+DetailView.args = {};

--- a/packages/ui/react-components/src/detail-view/DetailView.tsx
+++ b/packages/ui/react-components/src/detail-view/DetailView.tsx
@@ -10,12 +10,7 @@ export interface DetailViewProps {
     className?: string;
 }
 
-const DetailView = ({
-    title,
-    children,
-    contentAfterTitleRenderer,
-    className,
-}: DetailViewProps) => {
+const DetailView = ({ title, children, contentAfterTitleRenderer, className }: DetailViewProps) => {
     const cls = classnames('detailView', {
         [className]: !!className,
     });
@@ -24,9 +19,7 @@ const DetailView = ({
             <div className="detailView__titleContainer">
                 <Undertittel>{title}</Undertittel>
                 {contentAfterTitleRenderer && (
-                    <div className="detailView__nextToTitle">
-                        {contentAfterTitleRenderer()}
-                    </div>
+                    <div className="detailView__nextToTitle">{contentAfterTitleRenderer()}</div>
                 )}
             </div>
             {children}

--- a/packages/ui/react-components/src/info-panel/InfoPanel.stories.tsx
+++ b/packages/ui/react-components/src/info-panel/InfoPanel.stories.tsx
@@ -1,0 +1,18 @@
+import React, { ComponentProps } from 'react';
+import { Story } from '@storybook/react';
+import InfoPanelComponent from './../info-panel/InfoPanel';
+
+export default {
+    title: 'React Components',
+    component: InfoPanelComponent,
+};
+
+const Template: Story<ComponentProps<typeof InfoPanelComponent>> = (args) => (
+    <>
+        <InfoPanelComponent type="success">En type informasjon</InfoPanelComponent>
+        <InfoPanelComponent type="warning">En annen type informasjon</InfoPanelComponent>
+    </>
+);
+
+export const InfoPanel = Template.bind({});
+InfoPanel.args = {};

--- a/packages/ui/react-components/src/info-panel/InfoPanel.tsx
+++ b/packages/ui/react-components/src/info-panel/InfoPanel.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import classnames from 'classnames';
+import Panel from 'nav-frontend-paneler';
+import './infoPanel.less';
+
+interface InfoPanel {
+    children: React.ReactNode;
+    type: 'success' | 'warning';
+}
+
+const InfoPanel = ({ children, type }: InfoPanel) => {
+    const cls = classnames('infoPanel', `infoPanel--${type}`);
+    return <Panel className={cls}>{children}</Panel>;
+};
+
+export default InfoPanel;

--- a/packages/ui/react-components/src/info-panel/infoPanel.less
+++ b/packages/ui/react-components/src/info-panel/infoPanel.less
@@ -1,0 +1,9 @@
+.infoPanel {
+  &--success {
+    border: 2px solid #06893A;
+  }
+
+  &--warning {
+    border: 2px solid #ff9100;
+  }
+}

--- a/packages/ui/react-components/src/interactive-list/interactiveList.less
+++ b/packages/ui/react-components/src/interactive-list/interactiveList.less
@@ -5,47 +5,56 @@
 }
 
 .interactiveListElement {
-    padding: 0.5rem 0.5rem 0.4375rem 0.8125rem;
-    border: 1px solid #c6c2bf;
-    border-top: none;
+    border-bottom: 1px solid #c6c2bf;
     position: relative;
+
+    &:first-of-type {
+        border-top: 1px solid #c6c2bf;
+    }
 
     &:hover {
         background: #f2f7fc;
     }
+
+    &:last-of-type {
+        border-bottom: 0;
+    }
+
+    &__chevron {
+        transform: rotate(-90deg);
+        align-self: center;
+        margin-left: 1.125rem;
+        margin-right: 1.875rem;
+    }
 }
 
 .interactiveListElement--active {
-    padding-left: 0.5625rem;
     background: #f2f7fc;
-    border-left: 5px solid rgba(0, 103, 197, 1);
-    border-right: 1px solid #0067c5;
-    border-bottom: 1px solid #0067c5;
-    border-top: 1px solid #0067c5;
-}
 
-.interactiveListElement:first-child {
-    border-top: 1px solid #c6c2bf;
-}
+    &:before {
+        display: block;
+        content: '';
+        width: 0.3125rem;
+        height: 100%;
+        border-top-right-radius: 0.25rem;
+        border-bottom-right-radius: 0.25rem;
+        background-color: #0067c5;
+        position: absolute;
+        left: 0;
+        top: 0;
+    }
 
-.interactiveListElement--active:first-child {
-    border-top: 1px solid #0067c5;
-}
-
-.interactiveListElement--active:first-child {
-    border-top: 1px solid #0067c5;
-}
-
-.interactiveListElement--active:not(:first-child) {
-    border-top: 1px solid #0067c5;
-    margin-top: -1px;
+    p {
+        color: #262626;
+        font-weight: bold;
+        text-decoration: none;
+    }
 }
 
 .interactiveListElement__button {
+    padding: 0.9375rem 0 0.875rem 1.5rem;
     border: none;
     background: transparent;
-    padding: 0;
-    display: block;
     text-align: left;
     width: 100%;
     outline: none;
@@ -53,5 +62,10 @@
 
     &:focus-visible {
         outline: #0067c5 auto 1px;
+    }
+
+    &__contentContainer {
+        display: flex;
+        justify-content: space-between;
     }
 }

--- a/packages/ui/react-components/src/labelled-content/LabelledContent.stories.tsx
+++ b/packages/ui/react-components/src/labelled-content/LabelledContent.stories.tsx
@@ -1,0 +1,15 @@
+import React, { ComponentProps } from 'react';
+import { Story } from '@storybook/react';
+import LabelledContentComponent from './../labelled-content/LabelledContent';
+
+export default {
+    title: 'React Components',
+    component: LabelledContentComponent,
+};
+
+const Template: Story<ComponentProps<typeof LabelledContentComponent>> = (args) => (
+    <LabelledContentComponent label="Label" content="Content" />
+);
+
+export const LabelledContent = Template.bind({});
+LabelledContent.args = {};

--- a/packages/ui/react-components/src/labelled-content/LabelledContent.tsx
+++ b/packages/ui/react-components/src/labelled-content/LabelledContent.tsx
@@ -1,0 +1,17 @@
+import { Element } from 'nav-frontend-typografi';
+import React from 'react';
+import './labelledContent.less';
+
+interface LabelledContentProps {
+    label: string | React.ReactNode;
+    content: React.ReactNode;
+}
+
+const LabelledContent = ({ label, content }: LabelledContentProps) => (
+    <div className="labelledContent">
+        <Element className="labelledContent__label">{label}</Element>
+        <div className="labelledContent__content">{content}</div>
+    </div>
+);
+
+export default LabelledContent;

--- a/packages/ui/react-components/src/labelled-content/labelledContent.less
+++ b/packages/ui/react-components/src/labelled-content/labelledContent.less
@@ -1,0 +1,9 @@
+.labelledContent {
+  &__label {
+    font-weight: bold;
+  }
+
+  &__content {
+    margin-top: 0.5rem;
+  }
+}

--- a/packages/ui/react-components/src/link-button/LinkButton.stories.tsx
+++ b/packages/ui/react-components/src/link-button/LinkButton.stories.tsx
@@ -1,0 +1,17 @@
+import React, { ComponentProps } from 'react';
+import { Story } from '@storybook/react';
+import LinkButtonComponent from './../link-button/LinkButton';
+
+export default {
+    title: 'React Components',
+    component: LinkButtonComponent,
+};
+
+const Template: Story<ComponentProps<typeof LinkButtonComponent>> = (args) => (
+    <LinkButtonComponent onClick={() => console.log('I was clicked')} href="#">
+        Click me
+    </LinkButtonComponent>
+);
+
+export const LinkButton = Template.bind({});
+LinkButton.args = {};

--- a/packages/ui/react-components/src/link-button/LinkButton.tsx
+++ b/packages/ui/react-components/src/link-button/LinkButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import './linkButton.less';
+
+interface LinkButtonProps {
+    onClick: () => void;
+    children: React.ReactNode;
+    className?: string;
+}
+
+const LinkButton = ({ className, onClick, children }: LinkButtonProps) => {
+    const cls = `${className || ''} linkButton`;
+    return (
+        <button type="button" className={cls} onClick={onClick}>
+            {children}
+        </button>
+    );
+};
+
+export default LinkButton;

--- a/packages/ui/react-components/src/link-button/linkButton.less
+++ b/packages/ui/react-components/src/link-button/linkButton.less
@@ -1,0 +1,12 @@
+.linkButton {
+  padding: 0;
+  color: #0067c5;
+  border: none;
+  background: none;
+  border-bottom: 1px solid #0067c5;
+  height: 16px;
+  align-self: center;
+  font-size: 1rem;
+  line-height: 1rem;
+  cursor: pointer;
+}

--- a/packages/ui/react-components/src/navigation-with-detail-view/NavigationWithDetailView.stories.tsx
+++ b/packages/ui/react-components/src/navigation-with-detail-view/NavigationWithDetailView.stories.tsx
@@ -12,6 +12,7 @@ const Template: Story<ComponentProps<typeof NavigationWithDetailView>> = (args) 
     <NavigationWithDetailView
         {...args}
         navigationSection={() => <p>Navigasjon</p>}
+        showDetailSection={true}
         detailSection={() => (
             <DetailView title="Tittel">
                 <p>Detaljer</p>

--- a/packages/ui/react-components/src/navigation-with-detail-view/NavigationWithDetailView.tsx
+++ b/packages/ui/react-components/src/navigation-with-detail-view/NavigationWithDetailView.tsx
@@ -4,20 +4,18 @@ import './navigationWithDetailViewStyles.less';
 export interface NavigationWithDetailViewProps {
     navigationSection: () => React.ReactNode;
     detailSection: () => React.ReactNode;
+    showDetailSection: boolean;
 }
 
 const NavigationWithDetailView = ({
     navigationSection,
     detailSection,
+    showDetailSection,
 }: NavigationWithDetailViewProps) => {
     return (
         <div className="navigationWithDetailView">
-            <div className="navigationWithDetailView__navigationSection">
-                {navigationSection()}
-            </div>
-            <div className="navigationWithDetailView__detailSection">
-                {detailSection()}
-            </div>
+            <div className="navigationWithDetailView__navigationSection">{navigationSection()}</div>
+            {showDetailSection && <div className="navigationWithDetailView__detailSection">{detailSection()}</div>}
         </div>
     );
 };

--- a/packages/ui/react-components/src/navigation-with-detail-view/navigationWithDetailViewStyles.less
+++ b/packages/ui/react-components/src/navigation-with-detail-view/navigationWithDetailViewStyles.less
@@ -1,18 +1,20 @@
 .navigationWithDetailView {
-  display: flex;
-  align-items: baseline;
-
-  &__navigationSection {
     display: flex;
-    flex-direction: column;
-    flex-shrink: 0;
-    min-width: 17.5rem;
-  }
+    align-items: flex-start;
 
-  &__detailSection {
-    flex-wrap: wrap;
-    flex-grow: 1;
-    margin-left: 2rem;
-    flex-basis: 66%;
-  }
+    &__navigationSection {
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
+        min-width: 25.3125rem;
+        border-radius: 0.25rem;
+        border: 1px solid #c6c2bf;
+    }
+
+    &__detailSection {
+        flex-wrap: wrap;
+        flex-grow: 1;
+        margin-left: 1.25rem;
+        flex-basis: 66%;
+    }
 }

--- a/packages/ui/react-components/src/title-with-underline/TitleWithUnderline.stories.tsx
+++ b/packages/ui/react-components/src/title-with-underline/TitleWithUnderline.stories.tsx
@@ -1,0 +1,15 @@
+import React, { ComponentProps } from 'react';
+import { Story } from '@storybook/react';
+import TitleWithUnderlineComponent from './TitleWithUnderline';
+
+export default {
+    title: 'React Components',
+    component: TitleWithUnderlineComponent,
+};
+
+const Template: Story<ComponentProps<typeof TitleWithUnderlineComponent>> = (args) => (
+    <TitleWithUnderlineComponent>Title</TitleWithUnderlineComponent>
+);
+
+export const TitleWithUnderline = Template.bind({});
+TitleWithUnderline.args = {};

--- a/packages/ui/react-components/src/title-with-underline/TitleWithUnderline.tsx
+++ b/packages/ui/react-components/src/title-with-underline/TitleWithUnderline.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Undertittel as TitleComponent } from 'nav-frontend-typografi';
+import './titleWithUnderline.less';
+
+interface TitleWithUnderlineProps {
+    children: React.ReactNode;
+    titleClass?: string;
+    contentAfterTitleRenderer?: () => React.ReactNode;
+}
+
+const TitleWithUnderline = ({ children, titleClass, contentAfterTitleRenderer }: TitleWithUnderlineProps) => (
+    <>
+        <div className="titleWithUnderline">
+            <TitleComponent className={titleClass}>{children}</TitleComponent>
+            {contentAfterTitleRenderer && contentAfterTitleRenderer()}
+        </div>
+        <hr style={{ color: '#B7B1A9' }} />
+    </>
+);
+
+export default TitleWithUnderline;

--- a/packages/ui/react-components/src/title-with-underline/titleWithUnderline.less
+++ b/packages/ui/react-components/src/title-with-underline/titleWithUnderline.less
@@ -1,0 +1,5 @@
+.titleWithUnderline {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+}


### PR DESCRIPTION
Adds the following components to react-components package:
- title-with-underline
- basic-list
- info-panel
- interactive-list
- labelled-content
- link-button

Also adds missing showDetailSection prop to existing NavigationWithDetailView component
Also adds missing export of DetailViewProps interface