### PR TITLE
Fix test setup

### DIFF
--- a/packages/ui/react-components/src/form/Form.tsx
+++ b/packages/ui/react-components/src/form/Form.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
 import Box, { Margin } from '../box/Box';
 import './form.less';

--- a/packages/ui/react-components/tsconfig.json
+++ b/packages/ui/react-components/tsconfig.json
@@ -1,14 +1,13 @@
 {
-  "include": [
-    "./"
-  ],
-  "exclude": ["node_modules", "**.spec.ts"],
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "jsx": "react",
-    "experimentalDecorators": true,
-    "declaration": true,
-    "skipLibCheck": true,
-    "outDir": "./"
-  }
+    "include": ["./"],
+    "exclude": ["node_modules", "**.spec.ts"],
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "jsx": "react",
+        "experimentalDecorators": true,
+        "declaration": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "outDir": "./"
+    }
 }

--- a/packages/util/date-utils/index.ts
+++ b/packages/util/date-utils/index.ts
@@ -1,4 +1,4 @@
-import * as dayjs from 'dayjs';
+import dayjs from 'dayjs';
 
 export { prettifyDate } from './src/format';
 export { prettifyDateString } from './src/format';

--- a/packages/util/date-utils/package.json
+++ b/packages/util/date-utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@navikt/k9-date-utils",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "description": "A collection of period utils",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/util/date-utils/src/dateConstants.ts
+++ b/packages/util/date-utils/src/dateConstants.ts
@@ -1,6 +1,6 @@
 import dayjsWithPluginsAttached from './dayjsWithPluginsAttached';
 
-const today = dayjsWithPluginsAttached().utc(true).startOf('day');
+const today = dayjsWithPluginsAttached.startOf('day');
 const tomorrow = today.add(1, 'day').startOf('day');
 
 export default {

--- a/packages/util/date-utils/src/dayjsWithPluginsAttached.ts
+++ b/packages/util/date-utils/src/dayjsWithPluginsAttached.ts
@@ -1,8 +1,8 @@
-import * as dayjs from 'dayjs';
-import * as customParseFormat from 'dayjs/plugin/customParseFormat';
-import * as utc from 'dayjs/plugin/utc';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(customParseFormat);
 dayjs.extend(utc);
 
-export default dayjs;
+export default dayjs().utc(true);

--- a/packages/util/date-utils/src/initialize.ts
+++ b/packages/util/date-utils/src/initialize.ts
@@ -1,7 +1,12 @@
-import dayjs from './dayjsWithPluginsAttached';
+import dayjs from 'dayjs';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import utc from 'dayjs/plugin/utc';
 
-const supportedFormats = ['YYYY-MM-DD'];
+dayjs.extend(customParseFormat);
+dayjs.extend(utc);
+
+const supportedFormats = ['YYYY-MM-DD', 'DD.MM.YYYY'];
 
 export default function initializeDate(dateString: string) {
-    return dayjs(dateString, supportedFormats).utc(true);
+    return dayjs(dateString, supportedFormats).utc(true).startOf('day');
 }

--- a/packages/util/date-utils/tsconfig.json
+++ b/packages/util/date-utils/tsconfig.json
@@ -1,11 +1,12 @@
 {
-  "include": ["./"],
-  "exclude": ["node_modules", "**.spec.ts"],
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "declaration": true,
-    "outDir": "./",
-    "allowJs": true
-  }
+    "include": ["./"],
+    "exclude": ["node_modules", "**.spec.ts"],
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "declaration": true,
+        "outDir": "./",
+        "esModuleInterop": true,
+        "allowJs": true
+    }
 }

--- a/packages/util/period-utils/package.json
+++ b/packages/util/period-utils/package.json
@@ -2,7 +2,7 @@
     "name": "@navikt/k9-period-utils",
     "author": "NAV",
     "license": "MIT",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "A collection of period utils",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "@navikt/k9-array-utils": "^0.0.1",
-        "@navikt/k9-date-utils": "^0.0.4"
+        "@navikt/k9-date-utils": "^0.0.5"
     },
     "devDependencies": {
         "dayjs": "^1.10.4",

--- a/packages/util/period-utils/tsconfig.json
+++ b/packages/util/period-utils/tsconfig.json
@@ -1,11 +1,12 @@
 {
-  "include": ["./"],
-  "exclude": ["node_modules", "**.spec.ts"],
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "declaration": true,
-    "outDir": "./",
-    "allowJs": true
-  }
+    "include": ["./"],
+    "exclude": ["node_modules", "**.spec.ts"],
+    "extends": "../../../tsconfig.json",
+    "compilerOptions": {
+        "experimentalDecorators": true,
+        "declaration": true,
+        "outDir": "./",
+        "esModuleInterop": true,
+        "allowJs": true
+    }
 }


### PR DESCRIPTION
Fixed an issue related to local tests in package consumers failing because of missing esModuleInterop:true flag in tsconfigs

Also slightly changes the way we export date utils